### PR TITLE
webEntityZoneLoader Background wasn't unsettable

### DIFF
--- a/Bazaar/Scripts/webEntityZoneLoader.js
+++ b/Bazaar/Scripts/webEntityZoneLoader.js
@@ -170,7 +170,7 @@
                 }
                 
                 var webBackground = true;
-                if (webEntitiesToLoad[i].background) {
+                if (typeof webEntitiesToLoad[i].background !== 'undefined' && webEntitiesToLoad[i].background !== null) {
                     webBackground = webEntitiesToLoad[i].background;
                 }
                 


### PR DESCRIPTION
Small bug fix to allow the background to be set to false.